### PR TITLE
Screencopy to dmabuf presented using subsurfaces

### DIFF
--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -14,6 +14,7 @@ use cosmic::{
         Border,
     },
     iced_core::Shadow,
+    iced_sctk::subsurface_widget::Subsurface,
     widget,
 };
 use cosmic_comp_config::workspace::WorkspaceLayout;
@@ -284,7 +285,7 @@ fn toplevel_previews<'a>(
 
 fn capture_image(image: Option<&CaptureImage>) -> cosmic::Element<'_, Msg> {
     if let Some(image) = image {
-        widget::Image::new(image.img.clone()).into()
+        Subsurface::new(image.width, image.height, &image.wl_buffer).into()
     } else {
         widget::Image::new(widget::image::Handle::from_pixels(1, 1, vec![0, 0, 0, 255])).into()
     }

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -20,7 +20,7 @@ use cctk::{
     toplevel_management::ToplevelManagerState,
     wayland_client::{
         globals::registry_queue_init,
-        protocol::{wl_output, wl_seat},
+        protocol::{wl_buffer, wl_output, wl_seat},
         Connection, QueueHandle,
     },
     workspace::WorkspaceState,
@@ -30,6 +30,7 @@ use cosmic::iced::{
     self,
     futures::{executor::block_on, FutureExt, SinkExt},
 };
+use cosmic::iced_sctk::subsurface_widget::SubsurfaceBuffer;
 use futures_channel::mpsc;
 use std::{
     cell::RefCell,
@@ -83,7 +84,9 @@ pub enum Event {
 
 #[derive(Clone, Debug)]
 pub struct CaptureImage {
-    pub img: iced::widget::image::Handle,
+    pub width: u32,
+    pub height: u32,
+    pub wl_buffer: SubsurfaceBuffer,
 }
 
 pub fn subscription(conn: Connection) -> iced::Subscription<Event> {


### PR DESCRIPTION
Depends on https://github.com/pop-os/iced/pull/79.

This is meant to address the performance issues we have with shm screencopy, and rendering the workspaces view. We can screencopy to a dmabuf and attach it to a subsurface without copying image data to main memory, or having the iced renderer deal with the image data. If incremental rendering is done properly, this should preform pretty well even with Iced's software renderer, so we don't depend on a glow or wgpu renderer without or without dmabuf import.

I initially prototyped this in the `wip-dmabuf_nobuild` branch, which just used sctk and removed iced (also losing text rendering, iced widget layout system, and any other features provided with iced). This showed it worked and performed well, but it needed some way to integrate with other UI elements. Adding a `Subsurface` widget to iced-sctk provides a clean way to do this.

The changes here are fairly minimal since I've pushed a lot of the groundwork (sharing a Wayland connection with iced, gbm buffer allocation, etc.) for it to `master_jammy` while keeping that working with the existing shm+iced image approach for now.

Current issues:
* The iced-sctk PR needs to be cleaned up a bit before it's ready for merge.
* We'll need some way to preserve aspect ratio. Perhaps `Subsurface` should offer similar options to the `Image` widget.
* Dmabuf screencopy is working for toplevel capture, but failing for workspace capture
  - `[EGL] 0x300c (BAD_PARAMETER) eglCreateImageKHR: EGL_BAD_PARAMETER error: In eglCreateImageKHR: requested buffer attributes are not supported`
  - This is also failing on the older `wip-dmabuf_nobuild` branch, which worked before.
    * Some change in cosmic-comp, or a driver update?
* We'll need some way to make sure we don't re-use a buffer until `wl_buffer::release` is called, while swapping between at least two capture buffers. I'm not sure about the best way to handle that yet.