### PR TITLE
support CARGO_TARGET_DIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ includedir = $(prefix)/include
 datarootdir = $(prefix)/share
 datadir = $(datarootdir)
 
+CARGO_TARGET_DIR ?= target
 TARGET = debug
 DEBUG ?= 0
 ifeq ($(DEBUG),0)
@@ -32,7 +33,7 @@ $(BIN): Cargo.toml Cargo.lock src/main.rs vendor-check
 	cargo build $(ARGS) --bin ${BIN}
 
 install:
-	install -Dm0755 target/$(TARGET)/$(BIN) $(DESTDIR)$(bindir)/$(BIN)
+	install -Dm0755 $(CARGO_TARGET_DIR)/$(TARGET)/$(BIN) $(DESTDIR)$(bindir)/$(BIN)
 	install -Dm0644 data/$(APPID).desktop $(DESTDIR)$(datadir)/applications/$(APPID).desktop
 	install -Dm0644 data/$(APPID).svg $(DESTDIR)$(datadir)/icons/hicolor/scalable/apps/$(APPID).svg
 


### PR DESCRIPTION
Previously failed to install from source when CARGO_TARGET_DIR is set, because the Makefile assumed the target dir was './target'.