### PR TITLE
Don't panic if `dmabuf` global isn't present

### DIFF
--- a/src/backend/wayland/mod.rs
+++ b/src/backend/wayland/mod.rs
@@ -198,7 +198,9 @@ fn start(conn: Connection) -> mpsc::Receiver<Event> {
     let qh = event_queue.handle();
 
     let dmabuf_state = DmabufState::new(&globals, &qh);
-    dmabuf_state.get_default_feedback(&qh).unwrap();
+    if let Err(err) = dmabuf_state.get_default_feedback(&qh) {
+        log::warn!("dmabuf feedback not supported, only shm: {}", err);
+    }
 
     thread::spawn(move || {
         let (executor, scheduler) = calloop::futures::executor().unwrap();


### PR DESCRIPTION
Fixes support for cosmic-workspaces with shm capture with no hardware accelerated graphics present.

Requires https://github.com/pop-os/cosmic-comp/pull/685, or it will instead cause the compositor to panic.