### PR TITLE
Align interface closer to designs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-prefix ?= /usr/local
+prefix ?= /usr
 bindir = $(prefix)/bin
 libdir = $(prefix)/lib
 includedir = $(prefix)/include

--- a/i18n/en/cosmic_workspaces.ftl
+++ b/i18n/en/cosmic_workspaces.ftl
@@ -1,1 +1,2 @@
+workspace = Workspace { $number }
 new-workspace = New Workspace

--- a/i18n/sr-Cyrl/cosmic_workspaces.ftl
+++ b/i18n/sr-Cyrl/cosmic_workspaces.ftl
@@ -1,1 +1,2 @@
+workspace = Радни простор { $number }
 new-workspace = Нови радни простор

--- a/i18n/sr-Latn/cosmic_workspaces.ftl
+++ b/i18n/sr-Latn/cosmic_workspaces.ftl
@@ -1,1 +1,2 @@
+workspace = Radni prostor { $number }
 new-workspace = Novi radni prostor

--- a/src/main.rs
+++ b/src/main.rs
@@ -634,12 +634,11 @@ impl Application for App {
     }
 
     fn view_window(&self, id: iced::window::Id) -> cosmic::prelude::Element<Self::Message> {
-        use iced::widget::*;
         if let Some(surface) = self.layer_surfaces.get(&id) {
             return view::layer_surface(self, surface);
         }
         log::info!("NO VIEW");
-        text("workspaces").into()
+        cosmic::widget::text("workspaces").into()
     }
 
     fn on_close_requested(&self, _id: SurfaceId) -> Option<Msg> {

--- a/src/widgets/workspace_bar.rs
+++ b/src/widgets/workspace_bar.rs
@@ -1,5 +1,5 @@
 // Custom varian of row/column
-// Gives each child widget a maximim size on main axis of total/n
+// Gives each child widget a maximum size on main axis of total/n
 
 use cosmic::iced::{
     advanced::{


### PR DESCRIPTION
Fixes #56. Fixes #48, though the horizontal picker has slightly more height than it should, since there's some weird behavior with setting the width or height (e.g. Length::Shrink makes the picker take the entire screen, while Length::Fill makes it a smaller size), and making the height fixed could cause issues with different aspect ratios.
The toplevel title character limit is to reduce the chance of the close button being squished, and is temporary until iced is rebased, and the pin widget being used to place the button in the corner of the toplevel preview.
![screenshot-2024-12-23-20-41-42](https://github.com/user-attachments/assets/c4af4f50-0f62-4702-83db-5f320fa9ee98)

Should also fix the issue described in #30 (not sure why it was closed).

This makes the same change in the Makefile as the OSD rebase PR, since other repos use that prefix.