### PR TITLE
toplevels: Reflow onto two rows, when it can do so scaling down less

### DIFF
--- a/src/widgets/toplevels/mod.rs
+++ b/src/widgets/toplevels/mod.rs
@@ -15,11 +15,8 @@ use toplevel_layout::{LayoutToplevel, RowColToplevelLayout, ToplevelLayout};
 
 pub fn toplevels<Msg>(children: Vec<cosmic::Element<Msg>>) -> Toplevels<Msg> {
     Toplevels {
-        layout: RowColToplevelLayout {
-            // TODO configurable
-            spacing: 16,
-            axis: Axis::Horizontal,
-        },
+        // TODO configurable
+        layout: RowColToplevelLayout::new(Axis::Horizontal, 16),
         children,
         _msg: PhantomData,
     }

--- a/src/widgets/toplevels/mod.rs
+++ b/src/widgets/toplevels/mod.rs
@@ -11,19 +11,19 @@ use cosmic::iced::{
 use std::marker::PhantomData;
 
 mod toplevel_layout;
-use toplevel_layout::{LayoutToplevel, RowColToplevelLayout, ToplevelLayout};
+use toplevel_layout::{LayoutToplevel, ToplevelLayout, TwoRowColToplevelLayout};
 
 pub fn toplevels<Msg>(children: Vec<cosmic::Element<Msg>>) -> Toplevels<Msg> {
     Toplevels {
         // TODO configurable
-        layout: RowColToplevelLayout::new(Axis::Horizontal, 16),
+        layout: TwoRowColToplevelLayout::new(Axis::Horizontal, 16),
         children,
         _msg: PhantomData,
     }
 }
 
 pub struct Toplevels<'a, Msg> {
-    layout: RowColToplevelLayout,
+    layout: TwoRowColToplevelLayout,
     children: Vec<cosmic::Element<'a, Msg>>,
     _msg: PhantomData<Msg>,
 }

--- a/src/widgets/toplevels/toplevel_layout/mod.rs
+++ b/src/widgets/toplevels/toplevel_layout/mod.rs
@@ -7,6 +7,8 @@ use std::marker::PhantomData;
 mod axis_toplevel_layout;
 mod row_col_toplevel_layout;
 pub(crate) use row_col_toplevel_layout::RowColToplevelLayout;
+mod two_row_col_toplevel_layout;
+pub(crate) use two_row_col_toplevel_layout::TwoRowColToplevelLayout;
 
 #[derive(Debug)]
 pub(crate) struct LayoutToplevel<'a, S = Size> {

--- a/src/widgets/toplevels/toplevel_layout/row_col_toplevel_layout.rs
+++ b/src/widgets/toplevels/toplevel_layout/row_col_toplevel_layout.rs
@@ -11,6 +11,10 @@ pub(crate) struct RowColToplevelLayout {
 }
 
 impl RowColToplevelLayout {
+    pub fn new(axis: Axis, spacing: u32) -> Self {
+        Self { axis, spacing }
+    }
+
     // Get total requested main axis length if widget could have all the space
     pub fn requested_main_total(&self, toplevels: &[LayoutToplevel<'_, AxisSize>]) -> f32 {
         let total_spacing = self.spacing as usize * (toplevels.len().saturating_sub(1)).max(0);

--- a/src/widgets/toplevels/toplevel_layout/two_row_col_toplevel_layout.rs
+++ b/src/widgets/toplevels/toplevel_layout/two_row_col_toplevel_layout.rs
@@ -1,0 +1,72 @@
+use cosmic::iced::{advanced::layout::flex::Axis, Length};
+
+use super::{
+    axis_toplevel_layout::{AxisPoint, AxisRectangle, AxisSize, AxisToplevelLayout},
+    row_col_toplevel_layout::RowColToplevelLayout,
+    LayoutToplevel,
+};
+
+pub(crate) struct TwoRowColToplevelLayout(RowColToplevelLayout);
+
+impl TwoRowColToplevelLayout {
+    pub fn new(axis: Axis, spacing: u32) -> Self {
+        Self(RowColToplevelLayout::new(axis, spacing))
+    }
+}
+
+impl AxisToplevelLayout for TwoRowColToplevelLayout {
+    fn axis(&self) -> &Axis {
+        &self.0.axis
+    }
+
+    fn size(&self) -> AxisSize<Length> {
+        AxisSize {
+            main: Length::Fill,
+            cross: Length::Shrink,
+        }
+    }
+
+    fn layout(
+        &self,
+        max_limit: AxisSize,
+        toplevels: &[LayoutToplevel<'_, AxisSize>],
+    ) -> impl Iterator<Item = AxisRectangle> {
+        let requested_main_total = self.0.requested_main_total(&toplevels);
+        let scale_factor = self.0.scale_factor(max_limit, toplevels);
+
+        let half_max_limit = AxisSize {
+            main: max_limit.main,
+            cross: max_limit.cross / 2. - self.0.spacing as f32,
+        };
+
+        // See if two row layout is better
+        // TODO not a good fix if there is a large window and many smaller ones?
+        if requested_main_total > max_limit.main && toplevels.len() > 1 {
+            // decide best way to partition list
+            let (split_point, two_row_scale_factor) = (1..toplevels.len())
+                .map(|i| {
+                    let (top_row, bottom_row) = toplevels.split_at(i);
+                    let top_scale_factor = self.0.scale_factor(half_max_limit, top_row);
+                    let bottom_scale_factor = self.0.scale_factor(half_max_limit, bottom_row);
+                    (i, top_scale_factor.min(bottom_scale_factor))
+                })
+                .max_by(|(_, scale1), (_, scale2)| scale1.total_cmp(scale2))
+                .unwrap();
+            // Better layout
+            if two_row_scale_factor > scale_factor {
+                // TODO padding
+                let row1 = self.0.layout(half_max_limit, &toplevels[..split_point]);
+                let row2 = self
+                    .0
+                    .layout(half_max_limit, &toplevels[split_point..])
+                    .map(move |mut rect| {
+                        rect.origin.cross += max_limit.cross / 2. + self.0.spacing as f32;
+                        rect
+                    });
+                return itertools::Either::Left(row1.chain(row2));
+            }
+        }
+
+        itertools::Either::Right(self.0.layout(max_limit, toplevels))
+    }
+}


### PR DESCRIPTION
This is potentially a better for workspaces with more than a couple toplevels. But it doesn't help if one toplevel has a large height.

Probably the layout should consider the position of toplevels in the workspace. We should have that information in the toplevel info protocol now, though we'll need to think of how to handle stacks, and minimized windows.