### PR TITLE
Change workspace based on scroll events

### DIFF
--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -103,7 +103,10 @@ pub(crate) fn layer_surface<'a>(
                 .width(iced::Length::Fill),
         ),
     };
-    container.into()
+    let output = surface.output.clone();
+    widget::mouse_area(container)
+        .on_scroll(move |delta| Msg::OnScroll(output.clone(), delta))
+        .into()
 }
 
 fn close_button(on_press: Msg) -> cosmic::Element<'static, Msg> {


### PR DESCRIPTION
Works, I'm not sure how many pixels to interpret as a change to the workspace, and perhaps it should accumulate multiple deltas with a timer. Assuming some lower level of the stack isn't doing that already. I only see `ScrollDelta::Pixels` events, not `Lines`, though maybe that's relevant with a different type of input device.

The behavior would also be clearer with animation, though it doesn't seem to bad
(https://github.com/pop-os/cosmic-workspaces-epoch/issues/32).

Fixes https://github.com/pop-os/cosmic-workspaces-epoch/issues/34.