### PR TITLE
Workspace pinning and moving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,7 +1087,7 @@ dependencies = [
 [[package]]
 name = "cosmic-client-toolkit"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-protocols//?branch=main#6b05c2a157118979cb472a38455ba78ca9729196"
+source = "git+https://github.com/pop-os/cosmic-protocols//?branch=main#bc4af9183e0967802d7fbe91ba811a29ca6a3b67"
 dependencies = [
  "bitflags 2.8.0",
  "cosmic-protocols",
@@ -1151,7 +1151,7 @@ dependencies = [
 [[package]]
 name = "cosmic-protocols"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-protocols//?branch=main#6b05c2a157118979cb472a38455ba78ca9729196"
+source = "git+https://github.com/pop-os/cosmic-protocols//?branch=main#bc4af9183e0967802d7fbe91ba811a29ca6a3b67"
 dependencies = [
  "bitflags 2.8.0",
  "wayland-backend",
@@ -1672,7 +1672,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3185,7 +3185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4539,7 +4539,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4552,7 +4552,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5000,7 +5000,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix 0.38.44",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5844,7 +5844,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -80,5 +80,8 @@ pub enum Cmd {
         ExtWorkspaceHandleV1,
         wl_output::WlOutput,
     ),
+    MoveWorkspaceBefore(ExtWorkspaceHandleV1, ExtWorkspaceHandleV1),
+    MoveWorkspaceAfter(ExtWorkspaceHandleV1, ExtWorkspaceHandleV1),
     ActivateWorkspace(ExtWorkspaceHandleV1),
+    SetWorkspacePinned(ExtWorkspaceHandleV1, bool),
 }

--- a/src/backend/wayland/mod.rs
+++ b/src/backend/wayland/mod.rs
@@ -3,6 +3,7 @@
 
 use calloop_wayland_source::WaylandSource;
 use cctk::{
+    cosmic_protocols::workspace::v2::client::zcosmic_workspace_handle_v2,
     screencopy::{CaptureSource, ScreencopyState},
     sctk::{
         self,
@@ -106,10 +107,66 @@ impl AppData {
                     }
                 }
             }
+            // TODO version check
+            Cmd::MoveWorkspaceBefore(workspace_handle, other_workspace_handle) => {
+                if let Ok(workspace_manager) = self.workspace_state.workspace_manager().get() {
+                    if let Some(cosmic_workspace) = self
+                        .workspace_state
+                        .workspaces()
+                        .find(|w| w.handle == workspace_handle)
+                        .and_then(|w| w.cosmic_handle.as_ref())
+                    {
+                        if cosmic_workspace.version()
+                            >= zcosmic_workspace_handle_v2::REQ_MOVE_BEFORE_SINCE
+                        {
+                            cosmic_workspace.move_before(&other_workspace_handle, 0);
+                            workspace_manager.commit();
+                        }
+                    }
+                }
+            }
+            Cmd::MoveWorkspaceAfter(workspace_handle, other_workspace_handle) => {
+                if let Ok(workspace_manager) = self.workspace_state.workspace_manager().get() {
+                    if let Some(cosmic_workspace) = self
+                        .workspace_state
+                        .workspaces()
+                        .find(|w| w.handle == workspace_handle)
+                        .and_then(|w| w.cosmic_handle.as_ref())
+                    {
+                        if cosmic_workspace.version()
+                            >= zcosmic_workspace_handle_v2::REQ_MOVE_AFTER_SINCE
+                        {
+                            cosmic_workspace.move_after(&other_workspace_handle, 0);
+                            workspace_manager.commit();
+                        }
+                    }
+                }
+            }
             Cmd::ActivateWorkspace(workspace_handle) => {
                 if let Ok(workspace_manager) = self.workspace_state.workspace_manager().get() {
                     workspace_handle.activate();
                     workspace_manager.commit();
+                }
+            }
+            Cmd::SetWorkspacePinned(workspace_handle, pinned) => {
+                if let Ok(workspace_manager) = self.workspace_state.workspace_manager().get() {
+                    if let Some(cosmic_workspace) = self
+                        .workspace_state
+                        .workspaces()
+                        .find(|w| w.handle == workspace_handle)
+                        .and_then(|w| w.cosmic_handle.as_ref())
+                    {
+                        if cosmic_workspace.version() >= zcosmic_workspace_handle_v2::REQ_PIN_SINCE
+                        {
+                            // TODO check capability
+                            if pinned {
+                                cosmic_workspace.pin();
+                            } else {
+                                cosmic_workspace.unpin();
+                            }
+                            workspace_manager.commit();
+                        }
+                    }
                 }
             }
         }

--- a/src/dnd.rs
+++ b/src/dnd.rs
@@ -92,10 +92,36 @@ impl TryFrom<(Vec<u8>, std::string::String)> for DragWorkspace {
     }
 }
 
+// TODO name?
+pub enum Drag {
+    Toplevel,
+    Workspace,
+}
+
+impl cosmic::iced::clipboard::mime::AllowedMimeTypes for Drag {
+    fn allowed() -> Cow<'static, [String]> {
+        vec![TOPLEVEL_MIME.clone(), WORKSPACE_MIME.clone()].into()
+    }
+}
+
+impl TryFrom<(Vec<u8>, std::string::String)> for Drag {
+    type Error = ();
+    fn try_from((_bytes, mime_type): (Vec<u8>, String)) -> Result<Self, ()> {
+        if mime_type == *TOPLEVEL_MIME {
+            Ok(Self::Toplevel)
+        } else if mime_type == *WORKSPACE_MIME {
+            Ok(Self::Workspace)
+        } else {
+            Err(())
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 #[repr(u8)]
 pub enum DropTarget {
     WorkspaceSidebarEntry(ExtWorkspaceHandleV1, wl_output::WlOutput),
+    WorkspaceSidebarDragPlaceholder(ExtWorkspaceHandleV1, wl_output::WlOutput),
     OutputToplevels(ExtWorkspaceHandleV1, wl_output::WlOutput),
     #[allow(dead_code)]
     WorkspacesBar(wl_output::WlOutput),
@@ -109,6 +135,10 @@ impl DropTarget {
         match self {
             Self::WorkspaceSidebarEntry(workspace, _output) => {
                 // TODO consider workspace that span multiple outputs?
+                let id = workspace.id().protocol_id();
+                (u64::from(discriminant) << 32) | u64::from(id)
+            }
+            Self::WorkspaceSidebarDragPlaceholder(workspace, _output) => {
                 let id = workspace.id().protocol_id();
                 (u64::from(discriminant) << 32) | u64::from(id)
             }

--- a/src/widgets/match_size.rs
+++ b/src/widgets/match_size.rs
@@ -1,0 +1,145 @@
+//! Show one surface, sized to match the size of another (invisible) widget
+
+use cosmic::iced::{
+    advanced::{
+        layout, mouse, renderer,
+        widget::{Operation, Tree},
+        Clipboard, Layout, Shell, Widget,
+    },
+    event::{self, Event},
+    Length, Rectangle, Size,
+};
+use std::marker::PhantomData;
+
+pub fn match_size<
+    'a,
+    Msg,
+    T1: Into<cosmic::Element<'a, Msg>>,
+    T2: Into<cosmic::Element<'a, Msg>>,
+>(
+    matched: T1,
+    shown: T2,
+) -> MatchSize<'a, Msg> {
+    MatchSize {
+        matched: matched.into(),
+        shown: shown.into(),
+        _msg: PhantomData,
+    }
+}
+
+pub struct MatchSize<'a, Msg> {
+    matched: cosmic::Element<'a, Msg>,
+    shown: cosmic::Element<'a, Msg>,
+    _msg: PhantomData<Msg>,
+}
+
+impl<Msg> Widget<Msg, cosmic::Theme, cosmic::Renderer> for MatchSize<'_, Msg> {
+    delegate::delegate! {
+        to self.matched.as_widget() {
+            fn size(&self) -> Size<Length>;
+            fn size_hint(&self) -> Size<Length>;
+        }
+    }
+
+    fn operate(
+        &self,
+        tree: &mut Tree,
+        layout: Layout<'_>,
+        renderer: &cosmic::Renderer,
+        operation: &mut dyn Operation<()>,
+    ) {
+        self.matched
+            .as_widget()
+            .operate(&mut tree.children[0], layout, renderer, operation);
+        self.shown
+            .as_widget()
+            .operate(&mut tree.children[1], layout, renderer, operation);
+    }
+
+    fn on_event(
+        &mut self,
+        tree: &mut Tree,
+        event: Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &cosmic::Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Msg>,
+        viewport: &Rectangle,
+    ) -> event::Status {
+        self.shown.as_widget_mut().on_event(
+            &mut tree.children[1],
+            event,
+            layout,
+            cursor,
+            renderer,
+            clipboard,
+            shell,
+            viewport,
+        )
+    }
+
+    fn mouse_interaction(
+        &self,
+        tree: &Tree,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+        renderer: &cosmic::Renderer,
+    ) -> mouse::Interaction {
+        self.shown.as_widget().mouse_interaction(
+            &tree.children[1],
+            layout,
+            cursor,
+            viewport,
+            renderer,
+        )
+    }
+
+    fn layout(
+        &self,
+        tree: &mut Tree,
+        renderer: &cosmic::Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        // TODO?
+        self.matched
+            .as_widget()
+            .layout(&mut tree.children[0], renderer, limits)
+    }
+
+    fn draw(
+        &self,
+        tree: &Tree,
+        renderer: &mut cosmic::Renderer,
+        theme: &cosmic::Theme,
+        style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+    ) {
+        self.shown.as_widget().draw(
+            &tree.children[1],
+            renderer,
+            theme,
+            style,
+            layout,
+            cursor,
+            viewport,
+        );
+    }
+
+    fn children(&self) -> Vec<Tree> {
+        vec![Tree::new(&self.matched), Tree::new(&self.shown)]
+    }
+
+    fn diff(&mut self, tree: &mut Tree) {
+        tree.diff_children(&mut [&mut self.matched, &mut self.shown]);
+    }
+}
+
+impl<'a, Msg: 'a> From<MatchSize<'a, Msg>> for cosmic::Element<'a, Msg> {
+    fn from(widget: MatchSize<'a, Msg>) -> Self {
+        cosmic::Element::new(widget)
+    }
+}

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -19,6 +19,8 @@ mod toplevels;
 pub use toplevels::toplevels;
 mod visibility_wrapper;
 pub use visibility_wrapper::visibility_wrapper;
+mod match_size;
+pub use match_size::match_size;
 
 // Widget for debugging
 #[allow(dead_code)]


### PR DESCRIPTION
Initial pinning (https://github.com/pop-os/cosmic-workspaces-epoch/issues/108), based on compositor support in https://github.com/pop-os/cosmic-comp/pull/1191.

I guess https://github.com/pop-os/cosmic-icons needs a pinning icon? And I need to change more things for the styling here to match the design, but toggling pinning works.