### PR TITLE
Use gbm device from image copy protocol instead of default node

### DIFF
--- a/src/backend/wayland/buffer.rs
+++ b/src/backend/wayland/buffer.rs
@@ -84,22 +84,15 @@ impl AppData {
             return Ok(None);
         };
         let drm_dev = drm_dev.unwrap_or(feedback.main_device() as u64);
-        let Some((_, gbm)) = self.gbm_devices.gbm_device(drm_dev)? else {
+        let Some((dev_path, gbm)) = self.gbm_devices.gbm_device(drm_dev)? else {
             return Ok(None);
         };
         let formats = feedback.format_table();
 
-        let modifiers = feedback
-            .tranches()
+        let modifiers = modifiers
             .iter()
-            .flat_map(|x| &x.formats)
-            .filter_map(|x| formats.get(*x as usize))
-            .filter(|x| {
-                x.format == format
-                    && (!needs_linear || x.modifier == u64::from(gbm::Modifier::Linear))
-            })
-            .map(|x| gbm::Modifier::from(x.modifier))
-            .filter(|x| modifiers.contains(&u64::from(*x)))
+            .map(|modifier| gbm::Modifier::from(*modifier))
+            .filter(|modifier| !needs_linear || *modifier == gbm::Modifier::Linear)
             .collect::<Vec<_>>();
 
         if modifiers.is_empty() {

--- a/src/backend/wayland/dmabuf.rs
+++ b/src/backend/wayland/dmabuf.rs
@@ -7,8 +7,6 @@ use cctk::{
 };
 use cosmic::cctk;
 
-use std::{fs, io, os::unix::fs::MetadataExt, path::PathBuf};
-
 use wayland_protocols::wp::linux_dmabuf::zv1::client::{
     zwp_linux_buffer_params_v1::ZwpLinuxBufferParamsV1,
     zwp_linux_dmabuf_feedback_v1::ZwpLinuxDmabufFeedbackV1,
@@ -27,20 +25,6 @@ impl DmabufHandler for AppData {
         _proxy: &ZwpLinuxDmabufFeedbackV1,
         feedback: DmabufFeedback,
     ) {
-        if self.gbm.is_none() {
-            #[allow(clippy::unnecessary_cast)]
-            match find_gbm_device(feedback.main_device() as u64) {
-                Ok(Some(gbm)) => {
-                    self.gbm = Some(gbm);
-                }
-                Ok(None) => {
-                    log::error!("Gbm main device '{}' not found", feedback.main_device());
-                }
-                Err(err) => {
-                    log::error!("Failed to open gbm main device: {}", err);
-                }
-            }
-        }
         self.dmabuf_feedback = Some(feedback);
     }
     fn created(
@@ -65,18 +49,6 @@ impl DmabufHandler for AppData {
         _buffer: &wl_buffer::WlBuffer,
     ) {
     }
-}
-
-fn find_gbm_device(dev: u64) -> io::Result<Option<(PathBuf, gbm::Device<fs::File>)>> {
-    for i in std::fs::read_dir("/dev/dri")? {
-        let i = i?;
-        if i.metadata()?.rdev() == dev {
-            let file = fs::File::options().read(true).write(true).open(i.path())?;
-            log::info!("Opened gbm main device '{}'", i.path().display());
-            return Ok(Some((i.path(), gbm::Device::new(file)?)));
-        }
-    }
-    Ok(None)
 }
 
 sctk::delegate_dmabuf!(AppData);

--- a/src/backend/wayland/gbm_devices.rs
+++ b/src/backend/wayland/gbm_devices.rs
@@ -1,0 +1,43 @@
+use std::{
+    collections::hash_map::{self, HashMap},
+    fs, io,
+    os::unix::fs::MetadataExt,
+    path::{Path, PathBuf},
+};
+
+// TODO Purge gbm devices that are no longer needed/valid?
+#[derive(Default)]
+pub struct GbmDevices {
+    devices: HashMap<u64, (PathBuf, gbm::Device<fs::File>)>,
+}
+
+impl GbmDevices {
+    pub fn gbm_device(&mut self, dev: u64) -> io::Result<Option<(&Path, &gbm::Device<fs::File>)>> {
+        Ok(match self.devices.entry(dev) {
+            hash_map::Entry::Occupied(entry) => {
+                let (path, gbm) = entry.into_mut();
+                Some((path, gbm))
+            }
+            hash_map::Entry::Vacant(entry) => {
+                if let Some(value) = find_gbm_device(dev)? {
+                    let (path, gbm) = entry.insert(value);
+                    Some((path, gbm))
+                } else {
+                    None
+                }
+            }
+        })
+    }
+}
+
+fn find_gbm_device(dev: u64) -> io::Result<Option<(PathBuf, gbm::Device<fs::File>)>> {
+    for i in std::fs::read_dir("/dev/dri")? {
+        let i = i?;
+        if i.metadata()?.rdev() == dev {
+            let file = fs::File::options().read(true).write(true).open(i.path())?;
+            log::info!("Opened gbm main device '{}'", i.path().display());
+            return Ok(Some((i.path(), gbm::Device::new(file)?)));
+        }
+    }
+    Ok(None)
+}

--- a/src/backend/wayland/mod.rs
+++ b/src/backend/wayland/mod.rs
@@ -27,13 +27,15 @@ use cosmic::{
     },
 };
 use futures_channel::mpsc;
-use std::{cell::RefCell, collections::HashMap, fs, path::PathBuf, sync::Arc, thread};
+use std::{cell::RefCell, collections::HashMap, sync::Arc, thread};
 
 mod buffer;
 use buffer::Buffer;
 mod capture;
 use capture::Capture;
 mod dmabuf;
+mod gbm_devices;
+use gbm_devices::GbmDevices;
 mod screencopy;
 use screencopy::{ScreencopySession, SessionData};
 mod toplevel;
@@ -59,7 +61,7 @@ pub struct AppData {
     capture_filter: CaptureFilter,
     captures: RefCell<HashMap<CaptureSource, Arc<Capture>>>,
     dmabuf_feedback: Option<DmabufFeedback>,
-    gbm: Option<(PathBuf, gbm::Device<fs::File>)>,
+    gbm_devices: GbmDevices,
     thread_pool: futures_executor::ThreadPool,
 }
 
@@ -310,7 +312,7 @@ fn start(conn: Connection) -> mpsc::Receiver<Event> {
             capture_filter: CaptureFilter::default(),
             captures: RefCell::new(HashMap::new()),
             dmabuf_feedback: None,
-            gbm: None,
+            gbm_devices: GbmDevices::default(),
             thread_pool,
         };
 


### PR DESCRIPTION
Seems to fix https://github.com/pop-os/cosmic-workspaces-epoch/issues/45, at least to the extent I'm able to reproduce it, on an Intel+Nvidia laptop. There may be other multi-GPU issues.

I need to test this on my Amd+Nvidia system to make sure everything is still good there.