### PR TITLE
backend/wayland/vulkan: Enable `VK_EXT_physical_device_drm` extension

### DIFF
--- a/src/backend/wayland/vulkan.rs
+++ b/src/backend/wayland/vulkan.rs
@@ -14,10 +14,12 @@ impl Vulkan {
             api_version: vk::make_api_version(0, 1, 1, 0),
             ..Default::default()
         };
+        let extensions = &[c"VK_EXT_physical_device_drm".as_ptr()];
         let create_info = vk::InstanceCreateInfo {
             p_application_info: &app_info,
             ..Default::default()
-        };
+        }
+        .enabled_extension_names(extensions);
         let instance = unsafe { entry.create_instance(&create_info, None).ok()? };
         Some(Self {
             instance,


### PR DESCRIPTION
Fixes a segfault when run with `--no-default-features` to disable `wgpu`.

This doesn't seem to change anything when built normally, but it seems like a good idea to do this correctly. I think the very simple Vulkan code here should otherwise be correct.