### PR TITLE
feat: add middle mouse button support to close toplevel applications

### DIFF
--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -573,11 +573,12 @@ fn toplevel_preview(toplevel: &Toplevel, is_being_dragged: bool) -> cosmic::Elem
         .class(cosmic::theme::Button::Image)
         .on_press(Msg::ActivateToplevel(toplevel.handle.clone()));
 
-    crate::widgets::size_cross_nth(
+    widget::mouse_area(crate::widgets::size_cross_nth(
         vec![title.into(), preview.into()],
         Axis::Vertical,
         1, // Allocate width to match capture image
-    )
+    ))
+    .on_middle_press(Msg::CloseToplevel(toplevel.handle.clone()))
     .into()
 }
 


### PR DESCRIPTION
This pull request implements middle-click support on window previews. Users can now middle-click on a window preview to immediately close the corresponding instance.

Related to https://github.com/pop-os/cosmic-applets/pull/1318

This pull request is similar to PR #171 but differs in that the click handling is adjusted higher up in the window to account for the title and overall top spacing.