### PR TITLE
backend/wayland/vulkan: Fix use of Vulkan (correctly this time) 

### DIFF
--- a/src/backend/wayland/mod.rs
+++ b/src/backend/wayland/mod.rs
@@ -283,6 +283,14 @@ fn start(conn: Connection) -> mpsc::Receiver<Event> {
         // spawn an executor using one additional thread.
         let thread_pool = ThreadPool::builder().pool_size(1).create().unwrap();
 
+        let vulkan = vulkan::Vulkan::new();
+        if let Err(err) = &vulkan {
+            log::info!(
+                "Unable to initialize Vulkan: {}. Assuming now GPU workarounds needed.",
+                err
+            );
+        }
+
         let registry_state = RegistryState::new(&globals);
         let mut app_data = AppData {
             qh: qh.clone(),
@@ -300,7 +308,7 @@ fn start(conn: Connection) -> mpsc::Receiver<Event> {
             dmabuf_feedback: None,
             gbm_devices: GbmDevices::default(),
             thread_pool,
-            vulkan: vulkan::Vulkan::new(),
+            vulkan: vulkan.ok(),
         };
 
         let (cmd_sender, cmd_channel) = calloop::channel::channel();

--- a/src/backend/wayland/vulkan.rs
+++ b/src/backend/wayland/vulkan.rs
@@ -9,8 +9,8 @@ pub struct Vulkan {
 }
 
 impl Vulkan {
-    pub fn new() -> Option<Self> {
-        let entry = unsafe { ash::Entry::load().ok()? };
+    pub fn new() -> anyhow::Result<Self> {
+        let entry = unsafe { ash::Entry::load()? };
         let app_info = vk::ApplicationInfo {
             api_version: vk::make_api_version(0, 1, 1, 0),
             ..Default::default()
@@ -19,8 +19,8 @@ impl Vulkan {
             p_application_info: &app_info,
             ..Default::default()
         };
-        let instance = unsafe { entry.create_instance(&create_info, None).ok()? };
-        Some(Self {
+        let instance = unsafe { entry.create_instance(&create_info, None)? };
+        Ok(Self {
             _entry: entry,
             instance,
             device_name_cache: HashMap::new(),
@@ -30,6 +30,9 @@ impl Vulkan {
     pub fn device_name(&mut self, dev: u64) -> VkResult<Option<&str>> {
         if !self.device_name_cache.contains_key(&dev) {
             let value = self.device_name_uncached(dev);
+            if let Err(err) = &value {
+                log::error!("Failed to query Vulkan device properties: {}", err);
+            }
             self.device_name_cache.insert(dev, value);
         }
         self.device_name_cache


### PR DESCRIPTION
It seems https://github.com/pop-os/cosmic-workspaces-epoch/pull/280 was just wrong. I didn't test it correctly, and it actually prevented crashes simply because the Vulkan instance failed to create.

This failed because it's a device extension, not an instance extension (and we already check for the device extension).

The *real* issue seems to be simply the fact this was using the `Instance` after dropping the `Entry`. Which is easy enough to address.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

