### PR TITLE
backend/wayland: Use `calloop` executor to spawn future

### DIFF
--- a/src/backend/wayland/mod.rs
+++ b/src/backend/wayland/mod.rs
@@ -23,11 +23,7 @@ use cosmic::{
     cctk,
     iced::{
         self,
-        futures::{
-            FutureExt, SinkExt,
-            channel::mpsc,
-            executor::{ThreadPool, block_on},
-        },
+        futures::{FutureExt, SinkExt, channel::mpsc, executor::block_on},
     },
 };
 use std::{cell::RefCell, collections::HashMap, sync::Arc, thread};
@@ -66,7 +62,7 @@ pub struct AppData {
     captures: RefCell<HashMap<CaptureSource, Arc<Capture>>>,
     dmabuf_feedback: Option<DmabufFeedback>,
     gbm_devices: GbmDevices,
-    thread_pool: ThreadPool,
+    scheduler: calloop::futures::Scheduler<()>,
     vulkan: Option<vulkan::Vulkan>,
 }
 
@@ -279,9 +275,7 @@ fn start(conn: Connection) -> mpsc::Receiver<Event> {
     }
 
     thread::spawn(move || {
-        // TODO: The `calloop` executor doesn't seem to be working properly, so
-        // spawn an executor using one additional thread.
-        let thread_pool = ThreadPool::builder().pool_size(1).create().unwrap();
+        let (executor, scheduler) = calloop::futures::executor().unwrap();
 
         let registry_state = RegistryState::new(&globals);
         let mut app_data = AppData {
@@ -299,7 +293,7 @@ fn start(conn: Connection) -> mpsc::Receiver<Event> {
             captures: RefCell::new(HashMap::new()),
             dmabuf_feedback: None,
             gbm_devices: GbmDevices::default(),
-            thread_pool,
+            scheduler,
             vulkan: vulkan::Vulkan::new(),
         };
 
@@ -317,6 +311,10 @@ fn start(conn: Connection) -> mpsc::Receiver<Event> {
                     app_data.handle_cmd(msg)
                 }
             })
+            .unwrap();
+        event_loop
+            .handle()
+            .insert_source(executor, |(), (), _| {})
             .unwrap();
 
         loop {

--- a/src/backend/wayland/screencopy.rs
+++ b/src/backend/wayland/screencopy.rs
@@ -164,17 +164,19 @@ impl ScreencopyHandler for AppData {
         let conn = conn.clone();
         let release = session.release.take();
         let qh = qh.clone();
-        self.thread_pool.spawn_ok(async move {
-            if let Some(release) = release {
-                // Wait for buffer to be released by server
-                release.await;
-            }
-            let mut session = capture_clone.session.lock().unwrap();
-            let Some(session) = session.as_mut() else {
-                return;
-            };
-            session.attach_buffer_and_commit(&capture_clone, &conn, &qh);
-        });
+        self.scheduler
+            .schedule(async move {
+                if let Some(release) = release {
+                    // Wait for buffer to be released by server
+                    release.await;
+                }
+                let mut session = capture_clone.session.lock().unwrap();
+                let Some(session) = session.as_mut() else {
+                    return;
+                };
+                session.attach_buffer_and_commit(&capture_clone, &conn, &qh);
+            })
+            .unwrap();
 
         // Clear `buffer_damage` for front buffer; accumulate for other buffers.
         session.buffers.as_mut().unwrap()[0].buffer_damage.clear();


### PR DESCRIPTION
This should be fixed now that we're using `calloop` 0.14.4.

Spawning a thread for futures is excessive if we only use it to wait for buffer release.

This seems to be good, but testing this I'm looking into some inconsistent issues that seem to happen with or without this (though it's hard to be sure if there's a change).

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

