### PR TITLE
Make title and preview always the same width

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.93.0"
+components = ["clippy", "rustfmt"]

--- a/src/widgets/match_size.rs
+++ b/src/widgets/match_size.rs
@@ -2,7 +2,7 @@
 
 use cosmic::iced::advanced::widget::{Operation, Tree};
 use cosmic::iced::advanced::{Clipboard, Layout, Shell, Widget, layout, mouse, renderer};
-use cosmic::iced::event::{self, Event};
+use cosmic::iced::event::Event;
 use cosmic::iced::{Length, Rectangle, Size};
 use std::marker::PhantomData;
 

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -1,6 +1,6 @@
 use cosmic::iced::advanced::widget::{Id, Operation, Tree, tree};
 use cosmic::iced::advanced::{Clipboard, Layout, Shell, Widget, layout, mouse, overlay, renderer};
-use cosmic::iced::event::{self, Event};
+use cosmic::iced::event::Event;
 use cosmic::iced::{Length, Rectangle, Size, Vector};
 use std::marker::PhantomData;
 

--- a/src/widgets/mouse_interaction_wrapper.rs
+++ b/src/widgets/mouse_interaction_wrapper.rs
@@ -1,6 +1,6 @@
 use cosmic::iced::advanced::widget::{Id, Operation, Tree, tree};
 use cosmic::iced::advanced::{Clipboard, Layout, Shell, Widget, layout, mouse, overlay, renderer};
-use cosmic::iced::event::{self, Event};
+use cosmic::iced::event::Event;
 use cosmic::iced::{Length, Rectangle, Size, Vector};
 
 use std::marker::PhantomData;

--- a/src/widgets/size_cross_nth.rs
+++ b/src/widgets/size_cross_nth.rs
@@ -1,10 +1,10 @@
 // This widget defines it's cross axis size as the `index`th child's size
 
 use cosmic::iced::advanced::layout::flex::Axis;
-use cosmic::iced::advanced::layout::{self};
+use cosmic::iced::advanced::layout::{self, Limits};
 use cosmic::iced::advanced::widget::{Operation, Tree};
 use cosmic::iced::advanced::{Clipboard, Layout, Shell, Widget, mouse, renderer};
-use cosmic::iced::event::{self, Event};
+use cosmic::iced::event::Event;
 use cosmic::iced::{Length, Point, Rectangle, Size};
 use std::marker::PhantomData;
 
@@ -74,25 +74,38 @@ impl<Msg> Widget<Msg, cosmic::Theme, cosmic::Renderer> for SizeCrossNth<'_, Msg>
         &mut self,
         tree: &mut Tree,
         renderer: &cosmic::Renderer,
-        limits: &layout::Limits,
+        limits: &Limits,
     ) -> layout::Node {
         let max_main = self.axis.main(limits.max());
         let max_cross = self.axis.cross(limits.max());
 
-        // XXX cleaner solution
-        // Get layout of main widget, to set overall cross axis size
-        let (max_width, max_height) = self.axis.pack(max_main, max_cross);
-        let child_limits = layout::Limits::new(Size::ZERO, Size::new(max_width, max_height));
+        // Lay out all non-reference children to get their total main size
+        let mut total_main = 0.0;
+        for (i, (child, tree)) in self
+            .children
+            .iter_mut()
+            .zip(tree.children.iter_mut())
+            .enumerate()
+        {
+            if i != self.index {
+                let (max_width, max_height) = self.axis.pack(max_main - total_main, max_cross);
+                let child_limits = Limits::new(Size::ZERO, Size::new(max_width, max_height));
+                let layout = child.as_widget_mut().layout(tree, renderer, &child_limits);
+                total_main += self.axis.main(layout.size());
+            }
+        }
+
+        // Lay out reference child with remaining main to get max cross size
+        let (max_width, max_height) = self.axis.pack(max_main - total_main, max_cross);
+        let child_limits = Limits::new(Size::ZERO, Size::new(max_width, max_height));
         let layout = self.children[self.index].as_widget_mut().layout(
             &mut tree.children[self.index],
             renderer,
             &child_limits,
         );
-
         let max_cross = self.axis.cross(layout.size());
 
-        // XXX sill allocating maximum main axis?
-        // - what was it doing before?
+        // Lay out all children constrained to reference cross
         let mut total_main = 0.0;
         let nodes = self
             .children
@@ -100,8 +113,7 @@ impl<Msg> Widget<Msg, cosmic::Theme, cosmic::Renderer> for SizeCrossNth<'_, Msg>
             .zip(tree.children.iter_mut())
             .map(|(child, tree)| {
                 let (max_width, max_height) = self.axis.pack(max_main - total_main, max_cross);
-                let child_limits =
-                    layout::Limits::new(Size::ZERO, Size::new(max_width, max_height));
+                let child_limits = Limits::new(Size::ZERO, Size::new(max_width, max_height));
                 let mut layout = child.as_widget_mut().layout(tree, renderer, &child_limits);
                 // Center on cross axis
                 let cross = ((max_cross - self.axis.cross(layout.size())) / 2.).max(0.);

--- a/src/widgets/toplevels/mod.rs
+++ b/src/widgets/toplevels/mod.rs
@@ -2,7 +2,7 @@ use cosmic::iced::advanced::layout::flex::Axis;
 use cosmic::iced::advanced::layout::{self};
 use cosmic::iced::advanced::widget::{Operation, Tree};
 use cosmic::iced::advanced::{Clipboard, Layout, Shell, Widget, mouse, renderer};
-use cosmic::iced::event::{self, Event};
+use cosmic::iced::event::Event;
 use cosmic::iced::{Length, Rectangle, Size, Vector};
 use std::marker::PhantomData;
 

--- a/src/widgets/visibility_wrapper.rs
+++ b/src/widgets/visibility_wrapper.rs
@@ -3,7 +3,7 @@
 
 use cosmic::iced::advanced::widget::{Operation, Tree};
 use cosmic::iced::advanced::{Clipboard, Layout, Shell, Widget, layout, mouse, renderer};
-use cosmic::iced::event::{self, Event};
+use cosmic::iced::event::Event;
 use cosmic::iced::{Length, Rectangle, Size};
 use std::marker::PhantomData;
 

--- a/src/widgets/workspace_bar.rs
+++ b/src/widgets/workspace_bar.rs
@@ -6,7 +6,7 @@ use cosmic::iced::advanced::layout::{self};
 use cosmic::iced::advanced::widget::{Operation, Tree};
 use cosmic::iced::advanced::{Clipboard, Layout, Shell, Widget, mouse, renderer};
 use cosmic::iced::core::clipboard::DndDestinationRectangles;
-use cosmic::iced::event::{self, Event};
+use cosmic::iced::event::Event;
 use cosmic::iced::{Length, Point, Rectangle, Size};
 use std::marker::PhantomData;
 


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Prevents the title from being visually wider than the preview. This happens when the title height becomes a significant-enough chunk of max main that it interfered with the preview aspect ratio after its relayout with the previously unaccounted for title height, which caused its width to shrink (to keep the aspect ratio), while the title remained at `max_cross`. Happened often when the toplevel previews flow into 2 rows.

This first lays out all children except the one referenced by index, and then lays out the index child with the remaining main to get the cross. Then everything is laid out with that cross.