### PR TITLE
fix: use dmabuf screencopy on Arrow Lake

### DIFF
--- a/src/backend/wayland/buffer.rs
+++ b/src/backend/wayland/buffer.rs
@@ -91,12 +91,8 @@ impl AppData {
         if let Some(vulkan) = &mut self.vulkan
             && let Ok(Some(name)) = vulkan.device_name(drm_dev)
         {
-            // TODO Workaround: force shm on Meteor/Arrow/Lunar/Tiger Lake
-            if name.contains("TGL")
-                || name.contains("MTL")
-                || name.contains("ARL")
-                || name.contains("LNL")
-            {
+            // TODO Workaround: force shm on Meteor/Lunar/Tiger Lake
+            if name.contains("TGL") || name.contains("MTL") || name.contains("LNL") {
                 return Ok(None);
             }
         }


### PR DESCRIPTION
## Summary

Remove Arrow Lake (`ARL`) from the Intel GPU generations forced to use SHM screencopy.

The SHM workaround causes severe GPU load, low frame rates, and delayed cursor movement in the workspace overview on Intel Arrow Lake graphics. Allowing these devices to use GBM/DMABuf restores responsive rendering.

The existing SHM workarounds remain enabled for Tiger Lake, Meteor Lake, and Lunar Lake.

Closes #300.

## Investigation

The regression was bisected between releases 1.0.8 and 1.0.9.

In 1.0.8, Vulkan device detection failed, unintentionally bypassing the ARL workaround and allowing GBM/DMABuf screencopy. Version 1.0.9 fixed Vulkan initialization, causing ARL detection to succeed and activating the forced-SHM path.

Disabling captures eliminated the lag. Forcing GBM with captures enabled restored responsive cursor movement and substantially reduced GPU load.

The original workaround noted that Arrow Lake support was assumed without testing on Arrow Lake hardware.

## Testing

Hardware:

- Intel Core Ultra 7 265H
- Intel Arc Pro 140T
- Mesa 26.1.5-arch3.1
- CachyOS on Wayland

Results:

- 1.0.8 with GBM: smooth
- 1.0.9 with forced SHM: severe lag
- Current master with captures disabled: smooth
- Current master with captures but forced GBM: responsive
- No tearing, flickering, corrupted previews, or instability observed
- Repeated overview activation tested with multiple Kitty terminal windows in the active workspace
- `cargo fmt --check`
- `cargo build --release --bin cosmic-workspaces`

## AI Disclosure

OpenAI language models via OpenCode were used to investigate the regression, prepare the code change, and draft this PR description. I reviewed the change, understand its behavior, and can respond to review feedback.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
